### PR TITLE
Set actions container overflow to auto

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,7 +19,7 @@
 .actions {
   flex-grow: 1;
   flex-shrink: 1;
-  overflow: scroll;
+  overflow: auto;
   padding: 8px 0;
 }
 


### PR DESCRIPTION
When first opening the popup it is a bit confusing to have scrollbars in the X and Y direction.  Now it won't show the Y scroll bar till it populates fully.  Also I don't think there is a case for the scroll X bar.
